### PR TITLE
fix: resolve ODR violation for isCurrentlyPrinting

### DIFF
--- a/macos/ONLYOFFICE/AppDelegate.mm
+++ b/macos/ONLYOFFICE/AppDelegate.mm
@@ -56,6 +56,9 @@
 #import "PureLayout.h"
 #import "ascprinter.h"
 
+bool ASCPrinterContext::isCurrentlyPrinting = false;
+
+
 #ifndef _MAS
     #import "PFMoveApplication.h"
 #endif

--- a/macos/ONLYOFFICE/Code/Utils/ascprinter.h
+++ b/macos/ONLYOFFICE/Code/Utils/ascprinter.h
@@ -490,7 +490,5 @@ public:
 	}
 };
 
-// TODO: move outside of the header file
-bool ASCPrinterContext::isCurrentlyPrinting = false;
-
 #endif  // NSASCPRINTER_H
+


### PR DESCRIPTION
Move definition of static variable isCurrentlyPrinting out of the ascprinter.h header file and into AppDelegate.mm to prevent duplicate symbol linker errors in multi-unit compilation environments.

Closes Euro-Office/desktop-apps#26

Assisted-by: Antigravity:gemini-3.5-flash