### PR TITLE
Feature/configurable arch baseline

### DIFF
--- a/.docker/desktop-apps.bake.Dockerfile
+++ b/.docker/desktop-apps.bake.Dockerfile
@@ -19,6 +19,8 @@ FROM core-base AS desktop-linux
     ARG COMPANY_NAME
     ARG PRODUCT_NAME
     ARG BRANDING_DIR
+    ARG ARCH_TRIPLET=x64-linux-v2
+    ARG ARCH_MARCH_FLAGS=-march=x86-64-v2
 
     RUN apt-get -y update && \
         apt-get -y upgrade && \ 
@@ -100,6 +102,10 @@ FROM core-base AS desktop-linux
             -DVCPKG_MANIFEST_MODE=ON \
             -DVCPKG_MANIFEST_DIR="/core" \
             -DVCPKG_MANIFEST_FEATURES="desktop-editors" \
+            -DVCPKG_OVERLAY_TRIPLETS=/core/triplets \
+            -DVCPKG_TARGET_TRIPLET="${ARCH_TRIPLET}" \
+            -DCMAKE_CXX_FLAGS_RELEASE="${ARCH_MARCH_FLAGS}" \
+            -DCMAKE_C_FLAGS_RELEASE="${ARCH_MARCH_FLAGS}" \
             -DABOUT_PAGE_APP_NAME="${ABOUT_PAGE_APP_NAME}" \
             /desktop-apps/win-linux/ && \
         cmake --build . && \


### PR DESCRIPTION
## Summary

Makes the target x86-64 microarchitecture baseline for Linux builds configurable, instead of hardcoding it. Adds vcpkg overlay triplets (`x64-linux-v2` default, `x64-linux-baseline` for plain x86-64) and threads `ARCH_TRIPLET`/`ARCH_MARCH_FLAGS` through the Docker bake config and `build.sh`.

## Why

Raising the official baseline to x86-64-v2 (SSE4.2/POPCNT) gives Qt and other vcpkg-built dependencies access to SIMD-optimized code paths instead of falling back to unoptimized generic code — but it drops support for older CPUs that predate v2. Rather than the team maintaining a second, permanently-tracked toolchain to support that hardware, this exposes the microarchitecture as a build-time parameter so anyone who needs a legacy build can produce one themselves from the same sources, without affecting the default build path.

## Changes

- **`core`**: adds `triplets/x64-linux-v2.cmake` (default) and `triplets/x64-linux-baseline.cmake` vcpkg overlay triplets; wires `ARCH_TRIPLET`/`ARCH_MARCH_FLAGS` build args into the core cmake invocation in `.docker/core.bake.Dockerfile`.
- **`desktop-apps`**: same args threaded through `.docker/desktop-apps.bake.Dockerfile`'s vcpkg/cmake invocation, since Qt is built there via the vcpkg manifest.
- **Superproject**: declares `ARCH_TRIPLET` (default `x64-linux-v2`) and `ARCH_MARCH_FLAGS` (default `-march=x86-64-v2`) in `build/docker-bake.hcl` and `build/linux/docker-bake.hcl`, and exposes them as overridable environment variables in `build/linux/build.sh`.

## Usage

Default behavior is unchanged. To produce a baseline x86-64 build:

\`\`\`sh
ARCH_TRIPLET=x64-linux-baseline ARCH_MARCH_FLAGS=-march=x86-64 ./build.sh
\`\`\`

## Scope / non-goals

- No change to official release builds, CI, or support — those stay on x86-64-v2.
- Doesn't provide a one-flag "legacy build" experience end-to-end; someone building baseline still owns their own build/distribution.

https://github.com/Euro-Office/core/pull/125
https://github.com/Euro-Office/desktop-apps/pull/35
https://github.com/Euro-Office/DesktopEditors/pull/61