### PR TITLE
Automation cli feature

### DIFF
--- a/win-linux/CMakeLists.txt
+++ b/win-linux/CMakeLists.txt
@@ -183,7 +183,6 @@ set(COMMON_HEADERS
 set(COMMON_SOURCES
     src/prop/cmainwindowimpl.cpp
     src/prop/utils.cpp
-    src/utils.cpp
     src/docautomation.cpp
     src/windows/cmainwindow.cpp
     src/windows/cwindowbase.cpp

--- a/win-linux/CMakeLists.txt
+++ b/win-linux/CMakeLists.txt
@@ -162,6 +162,7 @@ set(COMMON_HEADERS
     src/cascapplicationmanagerwrapper_private.h
     src/casctabdata.h
     src/utils.h
+    src/docautomation.h
     src/chelp.h
     src/cfilechecker.h
     src/clogger.h
@@ -182,6 +183,8 @@ set(COMMON_HEADERS
 set(COMMON_SOURCES
     src/prop/cmainwindowimpl.cpp
     src/prop/utils.cpp
+    src/utils.cpp
+    src/docautomation.cpp
     src/windows/cmainwindow.cpp
     src/windows/cwindowbase.cpp
     src/windows/ceditorwindow.cpp

--- a/win-linux/src/chelp.cpp
+++ b/win-linux/src/chelp.cpp
@@ -58,7 +58,9 @@ void CHelp::out()
         "    --unlock-portals disable forced hiding of the Connect to the cloud button on the start page"
         "    --updates-appcast-channel=dev set development URL for updates\n"
         "    --updates-interval=<time> set update check interval in seconds (minimum 30 sec)\n"
-        "    --updates-reset reset all update options\n";
+        "    --updates-reset reset all update options\n"
+        "    <input-file> --convert-to=path/to/output.ext convert a document without starting the UI\n"
+        "    <input-file> --print-to-file=path/to/output.pdf render a document to PDF without starting the UI\n";
 
 #ifdef _WIN32
     FILE *pFile = NULL;

--- a/win-linux/src/docautomation.cpp
+++ b/win-linux/src/docautomation.cpp
@@ -31,10 +31,8 @@
 #include "../../../core/DesktopEditor/common/File.h"
 #include "../../../core/DesktopEditor/common/Directory.h"
 #include "../../../core/DesktopEditor/common/StringBuilder.h"
-#include "../../../core/Common/OfficeFileFormats.h"
 
 #include <iostream>
-#include <map>
 
 namespace {
     std::wstring GetFlagValue(const std::wstring& flag) {
@@ -49,30 +47,6 @@ namespace {
             }
         }
         return L"";
-    }
-
-    int FormatFromExtension(const std::wstring& sPath) {
-        static const std::map<std::wstring, int> formats = {
-            { L"docx", AVS_OFFICESTUDIO_FILE_DOCUMENT_DOCX },
-            { L"doc",  AVS_OFFICESTUDIO_FILE_DOCUMENT_DOC },
-            { L"odt",  AVS_OFFICESTUDIO_FILE_DOCUMENT_ODT },
-            { L"rtf",  AVS_OFFICESTUDIO_FILE_DOCUMENT_RTF },
-            { L"txt",  AVS_OFFICESTUDIO_FILE_DOCUMENT_TXT },
-            { L"html", AVS_OFFICESTUDIO_FILE_DOCUMENT_HTML },
-            { L"htm",  AVS_OFFICESTUDIO_FILE_DOCUMENT_HTML },
-            { L"pdf",  AVS_OFFICESTUDIO_FILE_CROSSPLATFORM_PDF },
-            { L"xlsx", AVS_OFFICESTUDIO_FILE_SPREADSHEET_XLSX },
-            { L"xls",  AVS_OFFICESTUDIO_FILE_SPREADSHEET_XLS },
-            { L"ods",  AVS_OFFICESTUDIO_FILE_SPREADSHEET_ODS },
-            { L"csv",  AVS_OFFICESTUDIO_FILE_SPREADSHEET_CSV },
-            { L"pptx", AVS_OFFICESTUDIO_FILE_PRESENTATION_PPTX },
-            { L"ppt",  AVS_OFFICESTUDIO_FILE_PRESENTATION_PPT },
-            { L"odp",  AVS_OFFICESTUDIO_FILE_PRESENTATION_ODP },
-        };
-        std::wstring sExt = NSFile::GetFileExtention(sPath);
-        for (auto& c : sExt) c = towlower(c);
-        auto it = formats.find(sExt);
-        return it != formats.end() ? it->second : 0;
     }
 }
 
@@ -106,12 +80,6 @@ int NSDocAutomation::Run() {
         }
     }
 
-    int nFormatTo = FormatFromExtension(sOutput);
-    if (0 == nFormatTo) {
-        std::wcerr << L"Unsupported output extension: " << sOutput << std::endl;
-        return 1;
-    }
-
     // A plain CAscApplicationManager, not the QObject-based GUI singleton
     // (AscAppManager::getInstance()) -- that one installs Qt event filters
     // in its constructor and crashes without a live QCoreApplication, which
@@ -124,30 +92,30 @@ int NSDocAutomation::Run() {
 
     std::wstring sTempDir = NSDirectory::CreateDirectoryWithUniqueName(NSFile::CFileBinary::GetTempPath());
 
-    // Mirrors CSimpleConverter::ThreadProc (fileconverter.h), the class the
-    // running editor uses for its own "export to PDF"/format-conversion
-    // actions, field for field (m_nFormatTo, m_sFontDir, m_sTempDir,
-    // m_bIsNoBase64=false) rather than the minimal from/to-only task this
-    // originally sent -- that minimal form parsed correctly by every
-    // external check (x2t reads back the exact bytes written, and replaying
-    // the exact captured file by hand against x2t succeeds every time) but
-    // still failed specifically when x2t was forked from this GUI binary.
+    // Formats are left for x2t to detect from the file extensions, the same
+    // way its own `x2t <from> <to>` mode does.
     NSStringUtils::CStringBuilder oBuilder;
     oBuilder.WriteString(L"<?xml version=\"1.0\" encoding=\"utf-8\"?><TaskQueueDataConvert><m_sFileFrom>");
     oBuilder.WriteEncodeXmlString(sInput);
     oBuilder.WriteString(L"</m_sFileFrom><m_sFileTo>");
     oBuilder.WriteEncodeXmlString(sOutput);
-    oBuilder.WriteString(L"</m_sFileTo><m_nFormatTo>");
-    oBuilder.WriteString(std::to_wstring(nFormatTo));
-    oBuilder.WriteString(L"</m_nFormatTo><m_sFontDir>");
+    oBuilder.WriteString(L"</m_sFileTo><m_sFontDir>");
     oBuilder.WriteEncodeXmlString(oManager.m_oSettings.fonts_cache_info_path);
-    oBuilder.WriteString(L"</m_sFontDir><m_bIsNoBase64>false</m_bIsNoBase64><m_sAllFontsPath>");
+    oBuilder.WriteString(L"</m_sFontDir><m_sAllFontsPath>");
     oBuilder.WriteEncodeXmlString(oManager.m_oSettings.fonts_cache_info_path + L"/AllFonts.js");
     oBuilder.WriteString(L"</m_sAllFontsPath><m_sTempDir>");
     oBuilder.WriteEncodeXmlString(sTempDir);
     oBuilder.WriteString(L"</m_sTempDir></TaskQueueDataConvert>");
 
-    std::wstring sXmlPath = NSFile::CFileBinary::CreateTempFileWithUniqueName(NSFile::CFileBinary::GetTempPath(), L"CLI");
+    // The ".xml" suffix is load-bearing: x2t only parses its argument as a
+    // TaskQueueDataConvert file when the name ends in ".xml" (see
+    // X2tConverter/src/main.cpp). Anything else is taken as the first of a
+    // bare `x2t <from> <to>` pair, leaving the destination empty and failing
+    // with "Empty sFileFrom or sFileTo".
+    std::wstring sTempName = NSFile::CFileBinary::CreateTempFileWithUniqueName(NSFile::CFileBinary::GetTempPath(), L"CLI");
+    if (NSFile::CFileBinary::Exists(sTempName))
+        NSFile::CFileBinary::Remove(sTempName);
+    std::wstring sXmlPath = sTempName + L".xml";
     NSFile::CFileBinary::SaveToFile(sXmlPath, oBuilder.GetData(), true);
 
     int nReturnCode = NSX2T::Convert(oManager.m_oSettings.file_converter_path + L"/x2t", sXmlPath, &oManager, true);

--- a/win-linux/src/docautomation.cpp
+++ b/win-linux/src/docautomation.cpp
@@ -29,9 +29,12 @@
 #include "../../../desktop-sdk/ChromiumBasedEditors/lib/include/applicationmanager.h"
 #include "../../../desktop-sdk/ChromiumBasedEditors/lib/src/x2t.h"
 #include "../../../core/DesktopEditor/common/File.h"
+#include "../../../core/DesktopEditor/common/Directory.h"
 #include "../../../core/DesktopEditor/common/StringBuilder.h"
+#include "../../../core/Common/OfficeFileFormats.h"
 
 #include <iostream>
+#include <map>
 
 namespace {
     std::wstring GetFlagValue(const std::wstring& flag) {
@@ -46,6 +49,30 @@ namespace {
             }
         }
         return L"";
+    }
+
+    int FormatFromExtension(const std::wstring& sPath) {
+        static const std::map<std::wstring, int> formats = {
+            { L"docx", AVS_OFFICESTUDIO_FILE_DOCUMENT_DOCX },
+            { L"doc",  AVS_OFFICESTUDIO_FILE_DOCUMENT_DOC },
+            { L"odt",  AVS_OFFICESTUDIO_FILE_DOCUMENT_ODT },
+            { L"rtf",  AVS_OFFICESTUDIO_FILE_DOCUMENT_RTF },
+            { L"txt",  AVS_OFFICESTUDIO_FILE_DOCUMENT_TXT },
+            { L"html", AVS_OFFICESTUDIO_FILE_DOCUMENT_HTML },
+            { L"htm",  AVS_OFFICESTUDIO_FILE_DOCUMENT_HTML },
+            { L"pdf",  AVS_OFFICESTUDIO_FILE_CROSSPLATFORM_PDF },
+            { L"xlsx", AVS_OFFICESTUDIO_FILE_SPREADSHEET_XLSX },
+            { L"xls",  AVS_OFFICESTUDIO_FILE_SPREADSHEET_XLS },
+            { L"ods",  AVS_OFFICESTUDIO_FILE_SPREADSHEET_ODS },
+            { L"csv",  AVS_OFFICESTUDIO_FILE_SPREADSHEET_CSV },
+            { L"pptx", AVS_OFFICESTUDIO_FILE_PRESENTATION_PPTX },
+            { L"ppt",  AVS_OFFICESTUDIO_FILE_PRESENTATION_PPT },
+            { L"odp",  AVS_OFFICESTUDIO_FILE_PRESENTATION_ODP },
+        };
+        std::wstring sExt = NSFile::GetFileExtention(sPath);
+        for (auto& c : sExt) c = towlower(c);
+        auto it = formats.find(sExt);
+        return it != formats.end() ? it->second : 0;
     }
 }
 
@@ -79,6 +106,12 @@ int NSDocAutomation::Run() {
         }
     }
 
+    int nFormatTo = FormatFromExtension(sOutput);
+    if (0 == nFormatTo) {
+        std::wcerr << L"Unsupported output extension: " << sOutput << std::endl;
+        return 1;
+    }
+
     // A plain CAscApplicationManager, not the QObject-based GUI singleton
     // (AscAppManager::getInstance()) -- that one installs Qt event filters
     // in its constructor and crashes without a live QCoreApplication, which
@@ -89,26 +122,38 @@ int NSDocAutomation::Run() {
     std::wstring sAppPath = NSFile::GetProcessDirectory();
     oManager.m_oSettings.file_converter_path = sAppPath + L"/converter";
 
-    // Only m_sFileFrom/m_sFileTo are set, matching x2t's own direct-CLI mode
-    // (`x2t <from> <to>`): format is auto-detected from file extensions.
+    std::wstring sTempDir = NSDirectory::CreateDirectoryWithUniqueName(NSFile::CFileBinary::GetTempPath());
+
+    // Mirrors CSimpleConverter::ThreadProc (fileconverter.h), the class the
+    // running editor uses for its own "export to PDF"/format-conversion
+    // actions, field for field (m_nFormatTo, m_sFontDir, m_sTempDir,
+    // m_bIsNoBase64=false) rather than the minimal from/to-only task this
+    // originally sent -- that minimal form parsed correctly by every
+    // external check (x2t reads back the exact bytes written, and replaying
+    // the exact captured file by hand against x2t succeeds every time) but
+    // still failed specifically when x2t was forked from this GUI binary.
     NSStringUtils::CStringBuilder oBuilder;
     oBuilder.WriteString(L"<?xml version=\"1.0\" encoding=\"utf-8\"?><TaskQueueDataConvert><m_sFileFrom>");
     oBuilder.WriteEncodeXmlString(sInput);
     oBuilder.WriteString(L"</m_sFileFrom><m_sFileTo>");
     oBuilder.WriteEncodeXmlString(sOutput);
-    oBuilder.WriteString(L"</m_sFileTo><m_sAllFontsPath>");
+    oBuilder.WriteString(L"</m_sFileTo><m_nFormatTo>");
+    oBuilder.WriteString(std::to_wstring(nFormatTo));
+    oBuilder.WriteString(L"</m_nFormatTo><m_sFontDir>");
+    oBuilder.WriteEncodeXmlString(oManager.m_oSettings.fonts_cache_info_path);
+    oBuilder.WriteString(L"</m_sFontDir><m_bIsNoBase64>false</m_bIsNoBase64><m_sAllFontsPath>");
     oBuilder.WriteEncodeXmlString(oManager.m_oSettings.fonts_cache_info_path + L"/AllFonts.js");
-    oBuilder.WriteString(L"</m_sAllFontsPath></TaskQueueDataConvert>");
+    oBuilder.WriteString(L"</m_sAllFontsPath><m_sTempDir>");
+    oBuilder.WriteEncodeXmlString(sTempDir);
+    oBuilder.WriteString(L"</m_sTempDir></TaskQueueDataConvert>");
 
-    // No BOM: x2t's XML parser doesn't skip it, so a BOM before <?xml ...?>
-    // leaves m_sFileFrom/m_sFileTo unparsed ("Empty sFileFrom or sFileTo"),
-    // confirmed by capturing and hand-testing the generated file against x2t.
     std::wstring sXmlPath = NSFile::CFileBinary::CreateTempFileWithUniqueName(NSFile::CFileBinary::GetTempPath(), L"CLI");
-    NSFile::CFileBinary::SaveToFile(sXmlPath, oBuilder.GetData(), false);
+    NSFile::CFileBinary::SaveToFile(sXmlPath, oBuilder.GetData(), true);
 
     int nReturnCode = NSX2T::Convert(oManager.m_oSettings.file_converter_path + L"/x2t", sXmlPath, &oManager, true);
 
     NSFile::CFileBinary::Remove(sXmlPath);
+    NSDirectory::DeleteDirectory(sTempDir);
 
     if (0 == nReturnCode) {
         std::wcout << L"OK: " << sOutput << std::endl;

--- a/win-linux/src/docautomation.cpp
+++ b/win-linux/src/docautomation.cpp
@@ -100,8 +100,11 @@ int NSDocAutomation::Run() {
     oBuilder.WriteEncodeXmlString(oManager.m_oSettings.fonts_cache_info_path + L"/AllFonts.js");
     oBuilder.WriteString(L"</m_sAllFontsPath></TaskQueueDataConvert>");
 
+    // No BOM: x2t's XML parser doesn't skip it, so a BOM before <?xml ...?>
+    // leaves m_sFileFrom/m_sFileTo unparsed ("Empty sFileFrom or sFileTo"),
+    // confirmed by capturing and hand-testing the generated file against x2t.
     std::wstring sXmlPath = NSFile::CFileBinary::CreateTempFileWithUniqueName(NSFile::CFileBinary::GetTempPath(), L"CLI");
-    NSFile::CFileBinary::SaveToFile(sXmlPath, oBuilder.GetData(), true);
+    NSFile::CFileBinary::SaveToFile(sXmlPath, oBuilder.GetData(), false);
 
     int nReturnCode = NSX2T::Convert(oManager.m_oSettings.file_converter_path + L"/x2t", sXmlPath, &oManager, true);
 

--- a/win-linux/src/docautomation.cpp
+++ b/win-linux/src/docautomation.cpp
@@ -1,36 +1,16 @@
 /*
- * (c) Copyright Ascensio System SIA 2010-2019
- *
- * This program is a free software product. You can redistribute it and/or
- * modify it under the terms of the GNU Affero General Public License (AGPL)
- * version 3 as published by the Free Software Foundation. In accordance with
- * Section 7(a) of the GNU AGPL its Section 15 shall be amended to the effect
- * that Ascensio System SIA expressly excludes the warranty of non-infringement
- * of any third-party rights.
- *
- * This program is distributed WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR  PURPOSE. For
- * details, see the GNU AGPL at: http://www.gnu.org/licenses/agpl-3.0.html
- *
- * The  interactive user interfaces in modified source and object code versions
- * of the Program must display Appropriate Legal Notices, as required under
- * Section 5 of the GNU AGPL version 3.
- *
- * All the Product's GUI elements, including illustrations and icon sets, as
- * well as technical writing content are licensed under the terms of the
- * Creative Commons Attribution-ShareAlike 4.0 International. See the License
- * terms at http://creativecommons.org/licenses/by-sa/4.0/legalcode
- *
-*/
+ * SPDX-FileCopyrightText: 2026 Euro-Office contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 
 #include "docautomation.h"
 #include "defines.h"
 #include "utils.h"
-#include "../../../desktop-sdk/ChromiumBasedEditors/lib/include/applicationmanager.h"
-#include "../../../desktop-sdk/ChromiumBasedEditors/lib/src/x2t.h"
-#include "../../../core/DesktopEditor/common/File.h"
-#include "../../../core/DesktopEditor/common/Directory.h"
-#include "../../../core/DesktopEditor/common/StringBuilder.h"
+#include "applicationmanager.h"
+#include "x2t.h"
+#include "common/File.h"
+#include "common/Directory.h"
+#include "common/StringBuilder.h"
 
 #include <iostream>
 
@@ -89,6 +69,12 @@ int NSDocAutomation::Run() {
     oManager.m_oSettings.SetUserDataPath(sUserDataPath.toStdWString());
     std::wstring sAppPath = NSFile::GetProcessDirectory();
     oManager.m_oSettings.file_converter_path = sAppPath + L"/converter";
+
+    // Normal startup builds the font cache via CheckFonts() before any document
+    // is touched; this path skips that startup sequence entirely, so on a
+    // profile that has never run the GUI (fresh install, container, CI) the
+    // AllFonts.js referenced below wouldn't exist yet. Block on it here.
+    oManager.CheckFonts(false);
 
     std::wstring sTempDir = NSDirectory::CreateDirectoryWithUniqueName(NSFile::CFileBinary::GetTempPath());
 

--- a/win-linux/src/docautomation.cpp
+++ b/win-linux/src/docautomation.cpp
@@ -1,0 +1,113 @@
+/*
+ * (c) Copyright Ascensio System SIA 2010-2019
+ *
+ * This program is a free software product. You can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License (AGPL)
+ * version 3 as published by the Free Software Foundation. In accordance with
+ * Section 7(a) of the GNU AGPL its Section 15 shall be amended to the effect
+ * that Ascensio System SIA expressly excludes the warranty of non-infringement
+ * of any third-party rights.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR  PURPOSE. For
+ * details, see the GNU AGPL at: http://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * The  interactive user interfaces in modified source and object code versions
+ * of the Program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU AGPL version 3.
+ *
+ * All the Product's GUI elements, including illustrations and icon sets, as
+ * well as technical writing content are licensed under the terms of the
+ * Creative Commons Attribution-ShareAlike 4.0 International. See the License
+ * terms at http://creativecommons.org/licenses/by-sa/4.0/legalcode
+ *
+*/
+
+#include "docautomation.h"
+#include "cascapplicationmanagerwrapper.h"
+#include "defines.h"
+#include "utils.h"
+#include "../../../desktop-sdk/ChromiumBasedEditors/lib/src/x2t.h"
+#include "../../../core/DesktopEditor/common/File.h"
+#include "../../../core/DesktopEditor/common/StringBuilder.h"
+
+#include <iostream>
+
+namespace {
+    std::wstring GetFlagValue(const std::wstring& flag) {
+        return InputArgs::contains(flag) ? InputArgs::argument_value(flag) : L"";
+    }
+
+    // First non-flag argument is treated as the input file path.
+    std::wstring GetInputFileArg() {
+        for (const auto& arg : InputArgs::arguments()) {
+            if (arg.rfind(L"--", 0) != 0) {
+                return arg;
+            }
+        }
+        return L"";
+    }
+}
+
+bool NSDocAutomation::ShouldRun() {
+    return InputArgs::contains(L"--convert-to") || InputArgs::contains(L"--print-to-file");
+}
+
+int NSDocAutomation::Run() {
+    bool bPrintToFile = InputArgs::contains(L"--print-to-file");
+    std::wstring sOutput = bPrintToFile ? GetFlagValue(L"--print-to-file") : GetFlagValue(L"--convert-to");
+    std::wstring sInput = GetInputFileArg();
+
+    if (sInput.empty() || sOutput.empty()) {
+        std::wcerr << L"Usage: DesktopEditors <input-file> --convert-to=<output-file>" << std::endl;
+        std::wcerr << L"       DesktopEditors <input-file> --print-to-file=<output-file.pdf>" << std::endl;
+        return 1;
+    }
+
+    if (!NSFile::CFileBinary::Exists(sInput)) {
+        std::wcerr << L"Input file not found: " << sInput << std::endl;
+        return 1;
+    }
+
+    // --print-to-file is an alias for --convert-to that forces PDF output,
+    // since x2t's PDF export is already what "Print" ultimately produces.
+    if (bPrintToFile) {
+        std::wstring sPdfExt = L".pdf";
+        if (sOutput.length() < sPdfExt.length() ||
+            0 != sOutput.compare(sOutput.length() - sPdfExt.length(), sPdfExt.length(), sPdfExt)) {
+            sOutput += sPdfExt;
+        }
+    }
+
+    CAscApplicationManagerWrapper& oManager = AscAppManager::getInstance();
+    QString sUserDataPath = Utils::getUserPath() + APP_DATA_PATH;
+    oManager.m_oSettings.SetUserDataPath(sUserDataPath.toStdWString());
+    std::wstring sAppPath = NSFile::GetProcessDirectory();
+    oManager.m_oSettings.file_converter_path = sAppPath + L"/converter";
+
+    // Only m_sFileFrom/m_sFileTo are set, matching x2t's own direct-CLI mode
+    // (`x2t <from> <to>`): format is auto-detected from file extensions.
+    NSStringUtils::CStringBuilder oBuilder;
+    oBuilder.WriteString(L"<?xml version=\"1.0\" encoding=\"utf-8\"?><TaskQueueDataConvert><m_sFileFrom>");
+    oBuilder.WriteEncodeXmlString(sInput);
+    oBuilder.WriteString(L"</m_sFileFrom><m_sFileTo>");
+    oBuilder.WriteEncodeXmlString(sOutput);
+    oBuilder.WriteString(L"</m_sFileTo><m_sAllFontsPath>");
+    oBuilder.WriteEncodeXmlString(oManager.m_oSettings.fonts_cache_info_path + L"/AllFonts.js");
+    oBuilder.WriteString(L"</m_sAllFontsPath></TaskQueueDataConvert>");
+
+    std::wstring sXmlPath = NSFile::CFileBinary::CreateTempFileWithUniqueName(NSFile::CFileBinary::GetTempPath(), L"CLI");
+    NSFile::CFileBinary::SaveToFile(sXmlPath, oBuilder.GetData(), true);
+
+    int nReturnCode = NSX2T::Convert(oManager.m_oSettings.file_converter_path + L"/x2t", sXmlPath, &oManager, true);
+
+    NSFile::CFileBinary::Remove(sXmlPath);
+
+    if (0 == nReturnCode) {
+        std::wcout << L"OK: " << sOutput << std::endl;
+    } else {
+        std::wcerr << L"Conversion failed (x2t exit code " << nReturnCode << L")" << std::endl;
+    }
+
+    return nReturnCode;
+}

--- a/win-linux/src/docautomation.cpp
+++ b/win-linux/src/docautomation.cpp
@@ -24,9 +24,9 @@
 */
 
 #include "docautomation.h"
-#include "cascapplicationmanagerwrapper.h"
 #include "defines.h"
 #include "utils.h"
+#include "../../../desktop-sdk/ChromiumBasedEditors/lib/include/applicationmanager.h"
 #include "../../../desktop-sdk/ChromiumBasedEditors/lib/src/x2t.h"
 #include "../../../core/DesktopEditor/common/File.h"
 #include "../../../core/DesktopEditor/common/StringBuilder.h"
@@ -79,7 +79,11 @@ int NSDocAutomation::Run() {
         }
     }
 
-    CAscApplicationManagerWrapper& oManager = AscAppManager::getInstance();
+    // A plain CAscApplicationManager, not the QObject-based GUI singleton
+    // (AscAppManager::getInstance()) -- that one installs Qt event filters
+    // in its constructor and crashes without a live QCoreApplication, which
+    // doesn't exist yet at this point (before any CEF/Qt startup).
+    CAscApplicationManager oManager;
     QString sUserDataPath = Utils::getUserPath() + APP_DATA_PATH;
     oManager.m_oSettings.SetUserDataPath(sUserDataPath.toStdWString());
     std::wstring sAppPath = NSFile::GetProcessDirectory();

--- a/win-linux/src/docautomation.h
+++ b/win-linux/src/docautomation.h
@@ -1,0 +1,38 @@
+/*
+ * (c) Copyright Ascensio System SIA 2010-2019
+ *
+ * This program is a free software product. You can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License (AGPL)
+ * version 3 as published by the Free Software Foundation. In accordance with
+ * Section 7(a) of the GNU AGPL its Section 15 shall be amended to the effect
+ * that Ascensio System SIA expressly excludes the warranty of non-infringement
+ * of any third-party rights.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR  PURPOSE. For
+ * details, see the GNU AGPL at: http://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * The  interactive user interfaces in modified source and object code versions
+ * of the Program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU AGPL version 3.
+ *
+ * All the Product's GUI elements, including illustrations and icon sets, as
+ * well as technical writing content are licensed under the terms of the
+ * Creative Commons Attribution-ShareAlike 4.0 International. See the License
+ * terms at http://creativecommons.org/licenses/by-sa/4.0/legalcode
+ *
+*/
+
+#ifndef DOCAUTOMATION_H
+#define DOCAUTOMATION_H
+
+// Handles the --convert-to and --print-to-file CLI flags by shelling out to
+// the packaged x2t converter, without starting CEF/Qt UI. --print-to-file is
+// an alias for --convert-to that forces PDF output, since x2t's PDF export is
+// already what "Print" ultimately produces.
+namespace NSDocAutomation {
+    bool ShouldRun();
+    int Run();
+}
+
+#endif // DOCAUTOMATION_H

--- a/win-linux/src/docautomation.h
+++ b/win-linux/src/docautomation.h
@@ -1,27 +1,7 @@
 /*
- * (c) Copyright Ascensio System SIA 2010-2019
- *
- * This program is a free software product. You can redistribute it and/or
- * modify it under the terms of the GNU Affero General Public License (AGPL)
- * version 3 as published by the Free Software Foundation. In accordance with
- * Section 7(a) of the GNU AGPL its Section 15 shall be amended to the effect
- * that Ascensio System SIA expressly excludes the warranty of non-infringement
- * of any third-party rights.
- *
- * This program is distributed WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR  PURPOSE. For
- * details, see the GNU AGPL at: http://www.gnu.org/licenses/agpl-3.0.html
- *
- * The  interactive user interfaces in modified source and object code versions
- * of the Program must display Appropriate Legal Notices, as required under
- * Section 5 of the GNU AGPL version 3.
- *
- * All the Product's GUI elements, including illustrations and icon sets, as
- * well as technical writing content are licensed under the terms of the
- * Creative Commons Attribution-ShareAlike 4.0 International. See the License
- * terms at http://creativecommons.org/licenses/by-sa/4.0/legalcode
- *
-*/
+ * SPDX-FileCopyrightText: 2026 Euro-Office contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 
 #ifndef DOCAUTOMATION_H
 #define DOCAUTOMATION_H

--- a/win-linux/src/main.cpp
+++ b/win-linux/src/main.cpp
@@ -39,6 +39,7 @@
 #include "utils.h"
 #include "chelp.h"
 #include "common/File.h"
+#include "docautomation.h"
 #include <QStyleFactory>
 
 
@@ -65,6 +66,9 @@ int main( int argc, char *argv[] )
         return 0;
     }
 #endif
+    if ( NSDocAutomation::ShouldRun() ) {
+        return NSDocAutomation::Run();
+    }
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     qputenv("QT_ENABLE_HIGHDPI_SCALING", "0");
 #else

--- a/win-linux/src/utils.cpp
+++ b/win-linux/src/utils.cpp
@@ -114,8 +114,12 @@ namespace InputArgs {
 
     auto argument_value(const std::wstring& param) -> std::wstring {
         for (const auto& item: in_args) {
-            if ( item.find(param) != std::wstring::npos ) {
-                return item.substr(param.size() + 1); // substring after '=' or ':' symbol
+            auto n = item.find(param);
+            if ( n != std::wstring::npos ) {
+                auto value_pos = n + param.size() + 1; // position after '=' or ':' symbol
+                if ( value_pos <= item.length() )
+                    return item.substr(value_pos);
+                return L"";
             }
         }
 


### PR DESCRIPTION
This is useful to allow Euro-Office to be used in automation workflows.

`--convert-to=<out>` / `--print-to-file=<out.pdf>` on the desktop binary, handled before any
CEF/Qt startup. Both flags are the same code path: `--print-to-file` just forces a `.pdf`
output suffix and calls the identical converter. There is no `QAscPrinterContext` print path
here — this is a plain x2t PDF export, same as `--convert-to out.pdf` would already produce.
I'd described it as reusing the print-to-file path in the original write-up; that wasn't
accurate, and I've corrected it here and in #58.

`x2t` already ships next to the desktop binary and already accepts `x2t <from> <to>` (or a full
`TaskQueueDataConvert` task XML). This PR doesn't add new conversion capability over that — it
adds a stable, documented, discoverable front door to it: no internal-tool compatibility
contract, no font-cache-path knowledge required, `--help` support, and a name a script author
would actually reach for. It intentionally exposes a subset of x2t's parameters (from/to/fonts/
temp only — no password, page ranges, CSV options, etc.); if that turns out to be limiting,
extending the flag set is a follow-up rather than a blocker for this PR.

DocBuilder is unrelated to this PR — it's a DocumentServer-side component, not part of the
desktop package, so there's no overlap with #321.

Implementation of https://github.com/Euro-Office/DesktopEditors/issues/58

---

### Changes since the last review round
- Reset `utils.cpp` to `main` and reapplied only the `argument_value` null-guard fix — the
  previous revision had accidentally pulled in ~120 unrelated lines from other branches
  (default-save-format, db-support, Wayland DPI code) that didn't compile.
- Dropped `src/utils.cpp` from `COMMON_SOURCES` in `win-linux/CMakeLists.txt` (it's already
  compiled via `prop/utils.cpp`'s `#include`; listing it again caused duplicate symbols).
- `docautomation.cpp`/`.h` now carry a Euro-Office SPDX header instead of Ascensio's upstream one.
- Replaced the `../../../` relative includes with the configured include dirs. This required
  promoting `x2t.h` from `desktop-sdk`'s private `lib/src/` to its public `lib/include/` — see
  [pplupo/Euro-Office_desktop-sdk@feature/document-automation-cli](https://github.com/pplupo/Euro-Office_desktop-sdk/tree/feature/document-automation-cli),
  which this PR now depends on.
- Added a synchronous `CheckFonts(false)` call before conversion, so a profile that's never run
  the GUI (fresh install, container, CI) gets its font cache built instead of failing on a
  missing `AllFonts.js`.
